### PR TITLE
Fix some compiler warnings (as of 0.21.0-nightly eb6cf012a).

### DIFF
--- a/src/bin/parse.rs
+++ b/src/bin/parse.rs
@@ -3,7 +3,6 @@ extern crate perfcnt;
 use std::io::prelude::*;
 use std::fs::File;
 use std::env;
-use std::path::Path;
 
 use perfcnt::linux::perf_file::PerfFile;
 
@@ -15,7 +14,7 @@ fn main() {
         let mut file = File::open(argument).expect("File does not exist");
         let mut buf: Vec<u8> = Vec::with_capacity(2*4096*4096);
         match file.read_to_end(&mut buf) {
-            Ok(len) => {
+            Ok(_) => {
                 let pf = PerfFile::new(buf);
                 println!("Header: {:?}", pf.header);
                 println!("Attributes: {:?}", pf.attrs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(type_macros)]
-
 extern crate libc;
 #[macro_use]
 extern crate x86;

--- a/tests/linux_generic_events.rs
+++ b/tests/linux_generic_events.rs
@@ -40,7 +40,7 @@ pub fn test_cache_events() {
             let res = pc.read().expect("Can not read the counter");
             assert!(res > 0);
         }
-        Err(e) => assert!(e.raw_os_error().unwrap() == 2)
+        Err(e) => assert_eq!(e.raw_os_error().unwrap(), 2)
     }
 }
 
@@ -59,7 +59,7 @@ pub fn test_hardware_counter() {
             let res = pc.read().expect("Can not read the counter");
             assert!(res < 100);
         }
-        Err(e) => assert!(e.raw_os_error().unwrap() == 2)
+        Err(e) => assert_eq!(e.raw_os_error().unwrap(), 2)
     }
 }
 /*


### PR DESCRIPTION
Also, use `assert_eq!` macro to make test failures easier to diagnose.