### PR TITLE
Move readme sample code to a doc test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,10 @@
 
 A library to program performance counters in rust.
 
-## Example library usage
-```rust
-let mut pc: PerfCounter = PerfCounterBuilderLinux::from_hardware_event(HardwareEventType::CacheMisses)
-pc.start().expect("Can not start the counter");
-pc.stop().expect("Can not start the counter");
-let res = pc.read().expect("Can not read the counter");
-println!("Measured {} cache misses.", res);
-```
-  * See examples/ directory for more code-snippets on how-to use the library to create counters.
-
 ## Documentation
+
   * [API Documentation](http://gz.github.io/rust-perfcnt/perfcnt/)
+  * See the [`examples/`](https://github.com/gz/rust-perfcnt/tree/master/examples) directory for more code-snippets on how to use the library to create counters.
 
 ## Provided Programs
   * *perfcnt-list*: Lists all architecture specific events available on the current machine (currently only supports Intel x86).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,17 @@
-#![feature(type_macros)]
+//! Example usage:
+//!
+//! ```
+//! use perfcnt::{AbstractPerfCounter, PerfCounter};
+//! use perfcnt::linux::{PerfCounterBuilderLinux, HardwareEventType};
+//!
+//! let mut pc: PerfCounter =
+//!     PerfCounterBuilderLinux::from_hardware_event(HardwareEventType::CacheMisses)
+//!         .finish().expect("Can not create the counter");
+//! pc.start().expect("Can not start the counter");
+//! pc.stop().expect("Can not start the counter");
+//! let res = pc.read().expect("Can not read the counter");
+//! println!("Measured {} cache misses.", res);
+//! ```
 
 extern crate libc;
 #[macro_use]


### PR DESCRIPTION
The sample code was not compatible with the current state of the API.

(This will cause a trivial conflict with #3)