### PR TITLE
bugfix: flags never passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,23 @@
 language: rust
-rust: nightly
+sudo: required
+env: TYPE=default RUST_BACKTRACE=1
+cache:
+  directories:
+  - $HOME/.cargo
+  - $TRAVIS_BUILD_DIR/target/debug
+  - $TRAVIS_BUILD_DIR/target/release
+script:
+- cargo build --verbose
+- cargo test --verbose
+- cargo build --release --verbose
+- cargo test --release --verbose
+matrix:
+  include:
+    - os: linux
+      rust: nightly
+    - os: linux
+      rust: nightly
+      env: TYPE=example RUST_BACKTRACE=1
+      script:
+        - cargo build --release --example context_switches
+        - sudo target/release/examples/context_switches

--- a/examples/context_switches.rs
+++ b/examples/context_switches.rs
@@ -1,0 +1,21 @@
+extern crate perfcnt;
+extern crate x86;
+
+use perfcnt::{PerfCounter, AbstractPerfCounter};
+use perfcnt::linux::SoftwareEventType as Software;
+use perfcnt::linux::PerfCounterBuilderLinux as Builder;
+
+pub fn main() {
+    let mut pc: PerfCounter = Builder::from_software_event(Software::ContextSwitches)
+        .on_cpu(0)
+        .for_all_pids()
+        .finish()
+        .expect("Could not create counter");
+
+    pc.start().expect("Can not start the counter");
+    std::thread::sleep(std::time::Duration::new(1,0));
+    pc.stop().expect("Can not stop the counter");;
+
+    println!("Context Switches/s: {:?}", pc.read().expect("Can not read counter"));
+    pc.reset().expect("Can not reset the counter");
+}

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -56,7 +56,7 @@ pub struct PerfCounterBuilderLinux {
     group: isize,
     pid: pid_t,
     cpu: isize,
-    flags: usize,
+    flags: i32,
     attrs: perf_format::EventAttr,
 }
 
@@ -265,7 +265,7 @@ impl PerfCounterBuilderLinux {
     ///
     /// This flag re-routes the output from an event to the group leader.
     pub fn set_flag_fd_output<'a>(&'a mut self) -> &'a mut PerfCounterBuilderLinux {
-        self.flags |= 0x0; //PERF_FLAG_FD_OUTPUT;
+        self.flags |= 0x02; //PERF_FLAG_FD_OUTPUT;
         self
     }
 
@@ -277,7 +277,7 @@ impl PerfCounterBuilderLinux {
     /// event  is  measured  only if the thread running on the monitored
     /// CPU belongs to the designated container (cgroup).
     pub fn set_flag_pid_cgroup<'a>(&'a mut self) -> &'a mut PerfCounterBuilderLinux {
-        self.flags |= 0x0; //PERF_FLAG_PID_CGROUP;
+        self.flags |= 0x04; //PERF_FLAG_PID_CGROUP;
         self
     }
 
@@ -604,13 +604,12 @@ impl PerfCounterBuilderLinux {
     }
 
     pub fn finish_sampling_counter(&self) -> Result<PerfCounter, io::Error> {
-        let flags = 0;
         let fd = perf_event_open(
             &self.attrs,
             self.pid,
             self.cpu as i32,
             self.group as i32,
-            flags,
+            self.flags,
         ) as ::libc::c_int;
         if fd < 0 {
             return Err(Error::from_raw_os_error(-fd));
@@ -625,13 +624,12 @@ impl PerfCounterBuilderLinux {
 
     /// Instantiate the performance counter.
     pub fn finish(&self) -> Result<PerfCounter, io::Error> {
-        let flags = 0;
         let fd = perf_event_open(
             &self.attrs,
             self.pid,
             self.cpu as i32,
             self.group as i32,
-            flags,
+            self.flags,
         ) as ::libc::c_int;
         if fd < 0 {
             return Err(Error::from_raw_os_error(-fd));


### PR DESCRIPTION
* flags PERF_FLAG_PID_CGROUP and PERF_FLAG_FD_OUTPUT had values of 0
* flags were never passed to perf_event_open()
* add new context switches example
* run the context switches example in travis to improve test coverage