### PR TITLE
Add derive(Debug, Clone, Copy) for enums

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -74,20 +74,26 @@ impl Default for PerfCounterBuilderLinux {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum HardwareEventType {
     /// Total cycles.  Be wary of what happens during CPU frequency scaling.
     CPUCycles = perf_event::PERF_COUNT_HW_CPU_CYCLES as isize,
 
-    /// Retired instructions.  Be careful, these can be affected by various issues, most notably hardware interrupt counts.
+    /// Retired instructions.  Be careful, these can be affected by various issues, most notably
+    /// hardware interrupt counts.
     Instructions = perf_event::PERF_COUNT_HW_INSTRUCTIONS as isize,
 
-    /// Cache  accesses.  Usually this indicates Last Level Cache accesses but this may vary depending on your CPU. This may include prefetches and
+    /// Cache accesses. Usually this indicates Last Level Cache accesses but this may vary depending
+    /// on your CPU. This may include prefetches and coherency messages; again this depends on the
+    /// design of your CPU.
     CacheReferences = perf_event::PERF_COUNT_HW_CACHE_REFERENCES as isize,
 
-    /// Cache misses.  Usually this indicates Last Level Cache misses; this is intended to be used  in  conjunction with the
+    /// Cache misses. Usually this indicates Last Level Cache misses; this is intended to be used in
+    /// conjunction with the [CacheReferences] event to calculate cache miss rates.
     CacheMisses = perf_event::PERF_COUNT_HW_CACHE_MISSES as isize,
 
-    /// Retired branch instructions.  Prior to Linux 2.6.34, this used the wrong event on AMD processors.
+    /// Retired branch instructions.  Prior to Linux 2.6.34, this used the wrong event on AMD
+    /// processors.
     BranchInstructions = perf_event::PERF_COUNT_HW_BRANCH_INSTRUCTIONS as isize,
 
     /// Mispredicted branch instructions.
@@ -106,6 +112,7 @@ pub enum HardwareEventType {
     RefCPUCycles = perf_event::PERF_COUNT_HW_REF_CPU_CYCLES as isize,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum SoftwareEventType {
     /// This reports the CPU clock, a high-resolution per-CPU timer.
     CpuClock = perf_event::PERF_COUNT_SW_CPU_CLOCK as isize,
@@ -146,6 +153,7 @@ pub enum SoftwareEventType {
     EmulationFaults = perf_event::PERF_COUNT_SW_EMULATION_FAULTS as isize,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum CacheId {
     /// For measuring Level 1 Data Cache
     L1D = perf_event::PERF_COUNT_HW_CACHE_L1D as isize,
@@ -171,6 +179,7 @@ pub enum CacheId {
     NODE = perf_event::PERF_COUNT_HW_CACHE_NODE as isize,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum CacheOpId {
     /// For read accesses
     Read = perf_event::PERF_COUNT_HW_CACHE_OP_READ as isize,
@@ -182,6 +191,7 @@ pub enum CacheOpId {
     Prefetch = perf_event::PERF_COUNT_HW_CACHE_OP_PREFETCH as isize,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum CacheOpResultId {
     /// To measure accesses.
     Access = perf_event::PERF_COUNT_HW_CACHE_RESULT_ACCESS as isize,
@@ -640,7 +650,7 @@ impl PerfCounterBuilderLinux {
         }
 
         Ok(PerfCounter {
-            fd: fd,
+            fd,
             file: unsafe { File::from_raw_fd(fd) },
             attributes: self.attrs,
         })
@@ -660,7 +670,7 @@ impl PerfCounterBuilderLinux {
         }
 
         Ok(PerfCounter {
-            fd: fd,
+            fd,
             file: unsafe { File::from_raw_fd(fd) },
             attributes: self.attrs,
         })
@@ -688,10 +698,10 @@ impl FileReadFormat {
         let id: u64 = read(ptr, 24);
 
         FileReadFormat {
-            value: value,
-            time_enabled: time_enabled,
-            time_running: time_running,
-            id: id,
+            value,
+            time_enabled,
+            time_running,
+            id,
         }
     }
 }
@@ -844,9 +854,9 @@ impl EventHeader {
         let misc: u16 = read(ptr, 4);
         let size: u16 = read(ptr, 6);
         EventHeader {
-            event_type: event_type,
-            misc: misc,
-            size: size,
+            event_type,
+            misc,
+            size,
         }
     }
 }
@@ -881,13 +891,13 @@ impl MMAPRecord {
         };
 
         MMAPRecord {
-            header: header,
-            pid: pid,
-            tid: tid,
-            addr: addr,
-            len: len,
-            pgoff: pgoff,
-            filename: filename,
+            header,
+            pid,
+            tid,
+            addr,
+            len,
+            pgoff,
+            filename,
         }
     }
 }
@@ -909,9 +919,9 @@ impl LostRecord {
         let lost: u64 = read(ptr, 16);
 
         LostRecord {
-            header: header,
-            id: id,
-            lost: lost,
+            header,
+            id,
+            lost,
         }
     }
 }
@@ -939,10 +949,10 @@ impl CommRecord {
             String::from(str::from_utf8(slice).unwrap())
         };
         CommRecord {
-            header: header,
-            pid: pid,
-            tid: tid,
-            comm: comm,
+            header,
+            pid,
+            tid,
+            comm,
         }
     }
 }
@@ -968,12 +978,12 @@ impl ExitRecord {
         let time: u64 = read(ptr, 24);
 
         ExitRecord {
-            header: header,
-            pid: pid,
-            ppid: ppid,
-            tid: tid,
-            ptid: ptid,
-            time: time,
+            header,
+            pid,
+            ppid,
+            tid,
+            ptid,
+            time,
         }
     }
 }
@@ -996,10 +1006,10 @@ impl ThrottleRecord {
         let stream_id: u64 = read(ptr, 24);
 
         ThrottleRecord {
-            header: header,
-            time: time,
-            id: id,
-            stream_id: stream_id,
+            header,
+            time,
+            id,
+            stream_id,
         }
     }
 }
@@ -1025,12 +1035,12 @@ impl ForkRecord {
         let time: u64 = read(ptr, 24);
 
         ForkRecord {
-            header: header,
-            pid: pid,
-            ppid: ppid,
-            tid: tid,
-            ptid: ptid,
-            time: time,
+            header,
+            pid,
+            ppid,
+            tid,
+            ptid,
+            time,
         }
     }
 }
@@ -1053,9 +1063,9 @@ impl ReadRecord {
         let frf: FileReadFormat = FileReadFormat::copy_from_raw_ptr(ptr.offset(16));
 
         ReadRecord {
-            header: header,
-            pid: pid,
-            tid: tid,
+            header,
+            pid,
+            tid,
             value: frf,
         }
     }
@@ -1156,27 +1166,27 @@ impl SampleRecord {
         let data_str: u64 = 0;
 
         SampleRecord {
-            header: header,
-            ip: ip,
-            pid: pid,
-            tid: tid,
-            time: time,
-            addr: addr,
-            id: id,
-            stream_id: stream_id,
-            cpu: cpu,
-            res: res,
-            period: period,
-            v: v,
-            ips: ips,
-            raw_sample: raw_sample,
-            lbr: lbr,
-            abi: abi,
-            regs: regs,
-            user_stack: user_stack,
-            dyn_size: dyn_size,
-            weight: weight,
-            data_str: data_str,
+            header,
+            ip,
+            pid,
+            tid,
+            time,
+            addr,
+            id,
+            stream_id,
+            cpu,
+            res,
+            period,
+            v,
+            ips,
+            raw_sample,
+            lbr,
+            abi,
+            regs,
+            user_stack,
+            dyn_size,
+            weight,
+            data_str,
         }
     }
 }
@@ -1287,7 +1297,7 @@ impl SamplingPerfCounter {
         .unwrap();
 
         SamplingPerfCounter {
-            pc: pc,
+            pc,
             map: res,
             events_size: 16 * 4096,
         }

--- a/src/linux/parser.rs
+++ b/src/linux/parser.rs
@@ -415,7 +415,7 @@ pub fn parse_event<'a>(input: &'a [u8], attrs: &'a Vec<EventAttr>) -> IResult<&'
     )
 }
 
-/// Parse a perf file section.
+// Parse a perf file section.
 named!(pub parse_file_section<&[u8], PerfFileSection>,
     do_parse!(
         offset: le_u64 >>
@@ -424,7 +424,7 @@ named!(pub parse_file_section<&[u8], PerfFileSection>,
     )
 );
 
-/// Parse a perf string.
+// Parse a perf string.
 named!(pub parse_perf_string<&[u8], String>,
     do_parse!(
         length: le_u32 >>
@@ -437,7 +437,7 @@ named!(pub parse_perf_string<&[u8], String>,
     )
 );
 
-/// Parse a perf string list.
+// Parse a perf string list.
 named!(pub parse_perf_string_list<&[u8], Vec<String> >,
     do_parse!(
         nr: le_u32 >>
@@ -554,7 +554,7 @@ pub fn parse_build_id_record<'a>(
     )
 }
 
-/// Parse a perf header
+// Parse a perf header
 named!(pub parse_header<&[u8], PerfFileHeader>,
     do_parse!(
         tag!("PERFILE2") >>
@@ -612,7 +612,7 @@ named!(pub parse_header<&[u8], PerfFileHeader>,
     )
 );
 
-/// Parse a perf header
+// Parse a perf header
 named!(pub parse_event_attr<&[u8], EventAttr>,
     do_parse!(
         attr_type: le_u32 >>


### PR DESCRIPTION
This will allow users to use enums in format strings via {:?}, and to pass the same variant to multiple functions (e.g. when creating access & miss counters programmatically for the same cache id).

Other drive-by changes:

- Fixed some truncated doc strings
- CLion was sprinkling suggestions for it, so I let it adopt the struct field initialization syntax shortcut when the field name is identical to the var name it's being set to
- Convert some not-used /// doc comments to // regular comments as per compiler warnings