### PR TITLE
Update x86 dependency to 0.45.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 edition = '2018'
 
 [dependencies.x86]
-version = "0.42.1"
+version = "0.45.0"
 features = ["performance-counter"]
 
 [dependencies]


### PR DESCRIPTION
Older versions of the x86 crate used the `llvm_asm!` macro, which was removed in the latest Rust nightly builds, from 2022-01-17 onwards. The latest x86 crate version, 0.45.0, fixes this problem. As this crate depends on older versions of the x86 crate, it is broken on the affected Rust nightly builds.

To fix this situation, update the x86 dependency to its latest version.