### PR TITLE
Update phf to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2"
 mmap = "0.1.*"
 byteorder = "1.3.4"
 nom = "4.2.3"
-phf = "0.8.0"
+phf = "0.9.0"
 
 [[bin]]
 name = "perfcnt-list"


### PR DESCRIPTION
The x86 dependency already pulls the newer version of phf, and as far as I can see this crate can also use that version without any source code changes. Having both crates depend on the same version of phf is good because it reduces build times (it is no longer necessary to download and compile two versions of the library) and potentially executable sizes.