### PR TITLE
Make perfcnt compile on non-x86 targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["performance", "counter", "events", "pmu", "perf"]
 license = "MIT"
 edition = '2018'
 
-[dependencies.x86]
-version = "0.47.0"
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies.x86]
+version = "0.49.0"
 features = ["performance-counter"]
 
 [dependencies]


### PR DESCRIPTION
This PR fixes compilation errors I encountered on a 64-bit arm machine - by making the intel/x86-specific bits of code only get conditionally compiled in on that architecture.