### PR TITLE
Correct version on master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perfcnt"
-version = "0.7.3"
+version = "0.8.1"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>", "Brian Martin <bmartin@twitter.com>", "Jens Breitbart <jbreitbart@gmail.com>", "Marshall Pierce <marshall@mpierce.org>"]
 description = "Library to configure and read hardware performance counters in rust."
 homepage = "https://github.com/gz/rust-perfcnt"


### PR DESCRIPTION
Correct the version (and bump very slightly) on master to `0.8.1`.

Currently, the mainline version of this crate is `0.7.3` which leaves a mystery `0.8.0` on crates.io that has unknown origins.

The version in crates.io seems not to be malicious in anyway, but causes confusion when this crate is used as a git dependency from the repo.

As such we bump this to `0.8.1` to be "the next development version" which means that using this should play nice.

Fixes: https://github.com/gz/rust-perfcnt/issues/31